### PR TITLE
Updated permissions and config according to new version 0.6

### DIFF
--- a/manifests/metrics-server.yaml
+++ b/manifests/metrics-server.yaml
@@ -38,7 +38,7 @@ rules:
   resources:
   - pods
   - nodes
-  - nodes/stats
+  - nodes/metrics
   - namespaces
   - configmaps
   verbs:
@@ -134,6 +134,7 @@ spec:
         - --kubelet-insecure-tls
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --kubelet-use-node-status-port
+        - --metric-resolution=15s
         image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -154,8 +155,14 @@ spec:
             path: /readyz
             port: https
             scheme: HTTPS
+          initialDelaySeconds: 20
           periodSeconds: 10
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000


### PR DESCRIPTION
Changes:
- Replaced permissions from `nodes/stats` to `node/metrics` according to changes of new version https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.0 . As the current version is failing with permissions error `"Failed to scrape node" err="request failed, status: \"403 Forbidden\"`
- Added some additional changes from [upstream](https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.1/components.yaml)